### PR TITLE
Patch go1.21 to v1.21.4 and golangci-lint to v1.55

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golangci/golangci-lint:v1.52.2
+FROM golangci/golangci-lint:v1.55
 
 FROM rockylinux:9
 ARG GOLANG_VERSION

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ REGISTRY := quay.io
 REPO_TAG ?= $(REGISTRY)/platform9/$(IMAGE_NAME)
 
 # image tag is the golang build number
-IMAGE_TAG := 1.21.3
+IMAGE_TAG := 1.21.4
 FULL_TAG :=$(REPO_TAG):$(IMAGE_TAG)
 
 default: build

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ REGISTRY := quay.io
 REPO_TAG ?= $(REGISTRY)/platform9/$(IMAGE_NAME)
 
 # image tag is the golang build number
-IMAGE_TAG := 1.21.1
+IMAGE_TAG := 1.21.3
 FULL_TAG :=$(REPO_TAG):$(IMAGE_TAG)
 
 default: build


### PR DESCRIPTION
Patch go1.21 to v1.21.4 and golangci-lint to v1.55 