### PR TITLE
Upgrade go 1.21 to 1.21.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golangci/golangci-lint:v1.55
+FROM golangci/golangci-lint:v1.56
 
 FROM rockylinux:9
 ARG GOLANG_VERSION

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ REGISTRY := quay.io
 REPO_TAG ?= $(REGISTRY)/platform9/$(IMAGE_NAME)
 
 # image tag is the golang build number
-IMAGE_TAG := 1.21.4
+IMAGE_TAG := 1.21.8
 FULL_TAG :=$(REPO_TAG):$(IMAGE_TAG)
 
 default: build


### PR DESCRIPTION
Patch go1.21 to v1.21.8 and golangci-lint to v1.56 from v1.55

Quay images: already published from private branch (from Teamcity) - will run from the main branch too. 
https://quay.io/repository/platform9/build-rocky-golang?tab=tags&tag=latest