### PR TITLE
PMK-6177 : Update builder build-centos7-golang to the latest patch for go 1.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golangci/golangci-lint:v1.56
+FROM golangci/golangci-lint:v1.57
 
 FROM rockylinux:9
 ARG GOLANG_VERSION

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ REGISTRY := quay.io
 REPO_TAG ?= $(REGISTRY)/platform9/$(IMAGE_NAME)
 
 # image tag is the golang build number
-IMAGE_TAG := 1.21.8
+IMAGE_TAG := 1.21.9
 FULL_TAG :=$(REPO_TAG):$(IMAGE_TAG)
 
 default: build


### PR DESCRIPTION
Patch go1.21 to v1.21.9 and golangci-lint to v1.57 from v1.56

Quay images: already published from private branch (from Teamcity) - will run from the main branch too.
https://quay.io/repository/platform9/build-rocky-golang?tab=tags&tag=latest