### PR TITLE
Update golang to 1.23.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golangci/golangci-lint:v1.61-alpine
+FROM golangci/golangci-lint:v1.62-alpine
 
 FROM rockylinux:9
 ARG GOLANG_VERSION

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ REGISTRY := quay.io
 REPO_TAG ?= $(REGISTRY)/platform9/$(IMAGE_NAME)
 
 # image tag is the golang build number
-IMAGE_TAG := 1.23.2
+IMAGE_TAG := 1.23.3
 FULL_TAG :=$(REPO_TAG):$(IMAGE_TAG)
 
 default: build


### PR DESCRIPTION
Teamcity build [#52](https://teamcity.platform9.horse/buildConfiguration/Platform9base_TestInfrastructure_BuildCentos7golang/3438286) [private/main/trilok/upgrade_go_1.23.3](https://teamcity.platform9.horse/buildConfiguration/Platform9base_TestInfrastructure_BuildCentos7golang?branch=private%2Fmain%2Ftrilok%2Fupgrade_go_1.23.3&buildTypeTab=overview&mode=builds)

