### PR TITLE
[go 1.23 branch] Update Makefile to patch go to 1.23.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golangci/golangci-lint:v1.61-alpine
+FROM golangci/golangci-lint:v1.62-alpine
 
 FROM rockylinux:9
 ARG GOLANG_VERSION

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ REGISTRY := quay.io
 REPO_TAG ?= $(REGISTRY)/platform9/$(IMAGE_NAME)
 
 # image tag is the golang build number
-IMAGE_TAG := 1.22.8
+IMAGE_TAG := 1.23.2
 FULL_TAG :=$(REPO_TAG):$(IMAGE_TAG)
 
 default: build

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ REGISTRY := quay.io
 REPO_TAG ?= $(REGISTRY)/platform9/$(IMAGE_NAME)
 
 # image tag is the golang build number
-IMAGE_TAG := 1.23.2
+IMAGE_TAG := 1.23.3
 FULL_TAG :=$(REPO_TAG):$(IMAGE_TAG)
 
 default: build

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ REGISTRY := quay.io
 REPO_TAG ?= $(REGISTRY)/platform9/$(IMAGE_NAME)
 
 # image tag is the golang build number
-IMAGE_TAG := 1.23.4
+IMAGE_TAG := 1.23.10
 FULL_TAG :=$(REPO_TAG):$(IMAGE_TAG)
 
 default: build

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ REGISTRY := quay.io
 REPO_TAG ?= $(REGISTRY)/platform9/$(IMAGE_NAME)
 
 # image tag is the golang build number
-IMAGE_TAG := 1.23.3
+IMAGE_TAG := 1.23.4
 FULL_TAG :=$(REPO_TAG):$(IMAGE_TAG)
 
 default: build


### PR DESCRIPTION
Airctl is built using this container - and the older patch version has security vulnerabilities as reported by Trivy and in https://github.com/platform9/airctl/pull/1324#issuecomment-2996123779

Teamcity build : [#64](https://teamcity.platform9.horse/buildConfiguration/Platform9base_TestInfrastructure_BuildCentos7golang/3930907) [private/main/trilok/upgrade_go_to_v1.23.10](https://teamcity.platform9.horse/buildConfiguration/Platform9base_TestInfrastructure_BuildCentos7golang?branch=private%2Fmain%2Ftrilok%2Fupgrade_go_to_v1.23.10&buildTypeTab=overview&mode=builds) 

Image : `quay.io/platform9/build-rocky-golang:1.23.12` https://quay.io/repository/platform9/build-rocky-golang?tab=tags&tag=1.23.12